### PR TITLE
[NRV] fix thread local traceid corruption

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/tracing/Tracer.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/tracing/Tracer.scala
@@ -3,8 +3,7 @@ package com.wajam.nrv.tracing
 import java.text.SimpleDateFormat
 import java.net.InetSocketAddress
 import com.wajam.nrv.tracing.Annotation.Message
-import util.DynamicVariable
-import com.wajam.nrv.utils.{UuidStringGenerator, IdGenerator, CurrentTime}
+import com.wajam.nrv.utils.{ThreadLocalVariable, UuidStringGenerator, IdGenerator, CurrentTime}
 
 /**
  * Trace context information. All trace events initiated from a common ancestor call share the same TraceId.

--- a/nrv-core/src/main/scala/com/wajam/nrv/utils/ThreadLocalVariable.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/utils/ThreadLocalVariable.scala
@@ -1,4 +1,4 @@
-package com.wajam.nrv.tracing
+package com.wajam.nrv.utils
 
 /**
  * Copied from DynamicVariable but do not inherit parent's thread value


### PR DESCRIPTION
Fix thread local traceid corruption caused by DynamicVariable which propagate the thread local value when a child thread is created
