### PR TITLE
Make sure the call method on the action adds the action.method to the OutMessage

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/data/Message.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/data/Message.scala
@@ -74,7 +74,6 @@ abstract class Message(params: Iterable[(String, Any)] = null,
     other.function = this.function
     other.error = this.error
     other.source = this.source
-    other.method = this.method
     other.destination = this.destination // TODO: should be cloned
     other.token = this.token
   }

--- a/nrv-core/src/main/scala/com/wajam/nrv/service/Action.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/service/Action.scala
@@ -56,6 +56,7 @@ class Action(val path: ActionPath,
   def call(message: OutMessage) {
     this.checkSupported()
 
+    message.method = method
     message.function = MessageType.FUNCTION_CALL
     this.callOutgoingHandlers(message)
   }

--- a/nrv-core/src/test/scala/com/wajam/nrv/service/TestAction.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/service/TestAction.scala
@@ -187,4 +187,22 @@ class TestAction extends FunSuite with BeforeAndAfter {
 
     action.stop()
   }
+
+  test("call() should add the action method in the OutMessage") {
+
+    val method = ActionMethod.POST
+    var interceptedOutMessage: OutMessage = null
+
+    val action = service.registerAction(new Action("/test/:param", req => {}, method) {
+
+      override protected[nrv] def callOutgoingHandlers(outMessage: OutMessage) {
+        interceptedOutMessage = outMessage
+      }
+    })
+    action.start()
+
+    action.call(new OutMessage(Map("call_key" -> "call_value")))
+
+    assert(method === interceptedOutMessage.method)
+  }
 }


### PR DESCRIPTION
This fixes a bug were two actions match the same path but differ only with the method. 
