### PR TITLE
Change logger scope for printing the cluster status

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/cluster/DynamicClusterManager.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/cluster/DynamicClusterManager.scala
@@ -112,7 +112,11 @@ abstract class DynamicClusterManager extends ClusterManager with Logging with Tr
 
     case object CheckCluster extends ClusterOperation
 
-    case object PrintCluster extends ClusterOperation
+    case object PrintCluster extends ClusterOperation with Logging {
+      def print() {
+        allServices.foreach(service => debug("\nLocal node: {}\n{}", cluster.localNode, service.printService))
+      }
+    }
 
     case object ForceSync extends ClusterOperation
 
@@ -157,7 +161,7 @@ abstract class DynamicClusterManager extends ClusterManager with Logging with Tr
 
           case PrintCluster =>
             try {
-              allServices.foreach(service => debug("\nLocal node: {}\n{}", cluster.localNode, service.printService))
+              PrintCluster.print()
             } catch {
               case e: Exception => error("Got an exception when printing cluster: ", e)
             } finally {

--- a/nrv-core/src/main/scala/com/wajam/nrv/service/ServiceMember.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/service/ServiceMember.scala
@@ -77,7 +77,7 @@ case class StatusTransitionAttemptEvent(member: ServiceMember, from: MemberStatu
 
 case class StatusTransitionEvent(member: ServiceMember, from: MemberStatus, to: MemberStatus) extends Event
 
-sealed trait MemberStatus extends Serializable;
+sealed trait MemberStatus extends Serializable
 
 object MemberStatus {
 


### PR DESCRIPTION
Add this in log4j.properties to print the cluster status every 5 seconds:
log4j.logger.com.wajam.nrv.cluster.DynamicClusterManager$OperationLoop$PrintCluster$=DEBUG
