### PR TITLE
Specified SBT version to use in build.properties file.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.11.2


### PR DESCRIPTION
This is allowing any installed SBT version to successfully compile the project.
See http://www.scala-sbt.org/release/docs/Detailed-Topics/Command-Line-Reference
