### PR TITLE
Can now set the last consistent timestamp to the consistent store.

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/cluster/StaticClusterManager.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/cluster/StaticClusterManager.scala
@@ -9,7 +9,10 @@ class StaticClusterManager extends ClusterManager {
 
   protected def initializeMembers() {
     allMembers.foreach {
-      case (service, member) => member.setStatus(MemberStatus.Up, triggerEvent = true)
+      case (service, member) => {
+        member.trySetStatus(MemberStatus.Up)
+        member.setStatus(MemberStatus.Up, triggerEvent = true)
+      }
     }
   }
 

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
@@ -5,7 +5,7 @@ import com.wajam.nrv.data.{OutMessage, Message, MessageType, InMessage}
 import com.wajam.nrv.utils.timestamp.{Timestamp, TimestampGenerator}
 import java.util.concurrent.atomic.AtomicReference
 import com.yammer.metrics.scala.Instrumented
-import com.wajam.nrv.utils.Event
+import com.wajam.nrv.utils.{VotableEvent, Event}
 import com.wajam.nrv.service.StatusTransitionEvent
 import persistence.{NullTransactionLog, FileTransactionLog}
 
@@ -58,6 +58,10 @@ class ConsistencyMasterSlave(val timestampGenerator: TimestampGenerator, txLogDi
     super.serviceEvent(event)
 
     event match {
+      case event: StatusTransitionAttemptEvent => {
+        // TODO: properly initialize and update the last consistent timestamp
+        store.setLastConsistentTimestamp(Timestamp(Long.MaxValue), service.getMemberTokenRanges(event.member))
+      }
       case event: StatusTransitionEvent if cluster.isLocalNode(event.member.node) => {
         event.to match {
           case MemberStatus.Up => {

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistentStore.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistentStore.scala
@@ -20,6 +20,13 @@ trait ConsistentStore {
   def getLastTimestamp(ranges: Seq[TokenRange]): Option[Timestamp]
 
   /**
+   * Set the most recent timestamp considered as consistent from Consistency for the specified token ranges.
+   * The consistency of the more recent records is unconfirmed and must not be included in processing tasks as
+   * GC or percolation.
+   */
+  def setLastConsistentTimestamp(timestamp: Timestamp, ranges: Seq[TokenRange])
+
+  /**
    * Returns the mutation messages from and up to the given timestamps inclusively for the specified token ranges.
    */
   def readTransactions(from: Timestamp, to: Timestamp, ranges: Seq[TokenRange]): Iterator[Message]
@@ -33,9 +40,4 @@ trait ConsistentStore {
    * Truncate all records at the given timestamp for the specified token.
    */
   def truncateAt(timestamp: Timestamp, token: Long)
-
-  /**
-   * Truncate all records from the given timestamp inclusively for the specified token ranges.
-   */
-  def truncateFrom(timestamp: Timestamp, tokens: Seq[TokenRange])
 }


### PR DESCRIPTION
Will be used to prevent GC or percolation to be performed beyond the last consistent timestamp known by ConsistencyMasterSlave. For now, the value is defaulted to MaxValue for all service member ranges. Default is set in the vetoable StatusTransitionAttemptEvent to ensure this is done BEFORE the service member status become UP.
