### PR TITLE
Recover consistency error even if transaction log is disabled

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
@@ -156,14 +156,12 @@ class ConsistencyMasterSlave(val timestampGenerator: TimestampGenerator, txLogDi
                 consistencyTimeout = math.max(service.responseTimeout + 2000, 15000),
                 commitFrequency = txLogCommitFrequency, onConsistencyError = {
                   metrics.consistencyError.mark()
-                  if (txLogEnabled) {
-                    this.synchronized {
-                      info("onConsistencyError: status={}, stateNew=Error, stateOld={}, member={}", event.member.status,
-                        consistencyStates.get(member.token), member)
-                      consistencyStates += (member.token -> MemberConsistencyState.Error)
-                    }
-                    cluster.clusterManager.trySetServiceMemberStatusDown(service, event.member)
+                  this.synchronized {
+                    info("onConsistencyError: status={}, stateNew=Error, stateOld={}, member={}", event.member.status,
+                      consistencyStates.get(member.token), member)
+                    consistencyStates += (member.token -> MemberConsistencyState.Error)
                   }
+                  cluster.clusterManager.trySetServiceMemberStatusDown(service, event.member)
                 })
               recorders += (member.token -> recorder)
               recorder.start()
@@ -392,6 +390,7 @@ class ConsistencyMasterSlave(val timestampGenerator: TimestampGenerator, txLogDi
       }
     )
   }
+
 }
 
 sealed trait MemberConsistencyState


### PR DESCRIPTION
Even if transaction log is not enabled, the service member must go down on consistency error in order to recover (i.e. to go up again). The TransactionRecorder prevent further message to be appended forever. The failed recorder is destroyed when the service member goes down and recreated when going up again.
