### PR TITLE
Fix transition from database replication source to transaction log source

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/persistence/FileTransactionLog.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/persistence/FileTransactionLog.scala
@@ -261,10 +261,12 @@ class FileTransactionLog(val service: String, val token: Long, val logDir: Strin
   }
 
   /**
-   * Read all the records from the specified request record timestamp. Returns an empty iterator if no request record
-   * with the specified timestamp is found. The implementation tries its best to read directly from the proper log
-   * file but have to read from extra log file if required. At worst all the log files may be read to locate the first
-   * record if no record exists for the specified timestamp.
+   * Read all the records from the specified request record timestamp. This method throw a NoSuchElementException
+   * if no request record with the specified timestamp is found.
+   * <p></p>
+   * The implementation tries its best to read directly from the proper log file but have to read from extra log file
+   * if required. At worst all the log files may be read to locate the first record if no record exists for the
+   * specified timestamp.
    */
   def read(timestamp: Timestamp): TransactionLogIterator = {
     readTimestampTimer.time {
@@ -286,7 +288,7 @@ class FileTransactionLog(val service: String, val token: Long, val logDir: Strin
         }
       }
 
-      result.getOrElse(EmptyTransactionLogIterator)
+      result.get
     }
   }
 

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/ConsistentStoreReplicationIterator.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/ConsistentStoreReplicationIterator.scala
@@ -9,19 +9,14 @@ import com.wajam.nrv.data.Message
  * Replication source iterator backed by a ConsistentStore. The iterator is bounded i.e. the first timestamp and the
  * last timestamp are known.
  */
-class ConsistentStoreReplicationIterator(member: ResolvedServiceMember, fromTimestamp: Timestamp,
-                                         toTimestamp: Timestamp, store: ConsistentStore)
+class ConsistentStoreReplicationIterator(member: ResolvedServiceMember, startTimestamp: Timestamp,
+                                         endTimestamp: Timestamp, store: ConsistentStore)
   extends ReplicationSourceIterator with Instrumented
 {
-  val from = fromTimestamp
-  val to = Some(toTimestamp)
-  private val itr = store.readTransactions(fromTimestamp, toTimestamp, member.ranges)
+  val start = startTimestamp
+  val end = Some(endTimestamp)
+  private val itr = store.readTransactions(startTimestamp, endTimestamp, member.ranges)
   private var lastTxTimestamp: Option[Long] = None
-
-  lazy private val nextMeter = metrics.meter("next", "next", member.scopeName)
-  private val lastTransactionTimestampGauge = metrics.gauge("last-tx-timestamp", member.scopeName) {
-    lastTxTimestamp.getOrElse(0L)
-  }
 
   def hasNext = itr.hasNext
 

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/ReplicationParam.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/ReplicationParam.scala
@@ -4,8 +4,8 @@ import com.wajam.nrv.data.{Message, MLong, MString}
 
 object ReplicationParam {
   val Token = "token"
-  val Start = "from_ts"
-  val End = "to_ts"
+  val Start = "start_ts"
+  val End = "end_ts"
   val Timestamp = "timestamp"
   val SubscriptionId = "sub_id"
   val Sequence = "seq"

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/ReplicationSourceIterator.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/ReplicationSourceIterator.scala
@@ -9,6 +9,24 @@ import com.wajam.nrv.utils.timestamp.Timestamp
  * timestamp.
  */
 trait ReplicationSourceIterator extends Iterator[Option[Message]] with Closable {
-  def from: Timestamp
-  def to: Option[Timestamp]
+  def start: Timestamp
+  def end: Option[Timestamp]
+
+  override def withFilter(p: (Option[Message]) => Boolean): ReplicationSourceIterator = {
+    val outer = this
+    val filtered = super.withFilter(p)
+
+    new ReplicationSourceIterator{
+      def start = outer.start
+      def end = outer.end
+
+      def hasNext = filtered.hasNext
+
+      def next() = filtered.next()
+
+      def close() {
+        outer.close()
+      }
+    }
+  }
 }

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/ReplicationSubscriber.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/ReplicationSubscriber.scala
@@ -165,12 +165,11 @@ class ReplicationSubscriber(service: Service, store: ConsistentStore, maxIdleDur
               subscriptions.get(subscribe.member) match {
                 case Some(Left(_)) => {
                   info("Send subscribe request to source for pending subscription. {}", subscribe.member)
-                  // TODO: remove var
-                  var params: Map[String, MValue] = Map(ReplicationParam.Token -> subscribe.member.token.toString)
+                  var params: Map[String, MValue] = Map()
+                  params += (ReplicationParam.Token -> subscribe.member.token.toString)
                   subscribe.txLog.getLastLoggedRecord.map(_.consistentTimestamp) match {
                     case Some(Some(lastTimestamp)) => {
-                      val startTimestamp = lastTimestamp.value + 1
-                      params += (ReplicationParam.Start -> startTimestamp.toString)
+                      params += (ReplicationParam.Start -> lastTimestamp.toString)
                     }
                     case _ => {
                       // No records in transaction log. Omit start if the local store is empty.

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/persistence/TestFileTransactionLog.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/persistence/TestFileTransactionLog.scala
@@ -477,11 +477,17 @@ class TestFileTransactionLog extends TestTransactionBase with BeforeAndAfter {
     fileTxLog.read(Timestamp(900)).toList should be(List(r8, r9)) // and records must be read as written.
 
     // Beyond end
-    fileTxLog.read(Timestamp(9999)).toList should be(List())
+    evaluating {
+      fileTxLog.read(Timestamp(9999)).toList should be(List())
+    } should produce[NoSuchElementException]
 
     // Unknown timestamp
-    fileTxLog.read(Timestamp(-1)).toList should be(List())
-    fileTxLog.read(Timestamp(850)).toList should be(List())
+    evaluating {
+      fileTxLog.read(Timestamp(-1)).toList should be(List())
+    } should produce[NoSuchElementException]
+    evaluating {
+      fileTxLog.read(Timestamp(850)).toList should be(List())
+    } should produce[NoSuchElementException]
   }
 
   test("read should skip empty log files") {


### PR DESCRIPTION
- Explicitly fail when trying to read a missing tx log record by timestamp instead of returning an empty iterator
- Replication start timestamp is now exclusive and not published to slave.
- Rename from/to replication source field to start/end
