### PR TITLE
Removed auto appended Index while pending transactions are empty.

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/TransactionRecorder.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/TransactionRecorder.scala
@@ -256,10 +256,14 @@ class TransactionRecorder(val member: ResolvedServiceMember, val txLog: Transact
             }
             case _ =>
           }
-          consistentTimestamp = Some(tx.timestamp)
 
-          // Check for more consistent transaction
           if (!pendingTransactions.isEmpty) {
+            // Only update the consistent timestamp if there are pending transactions. This is to prevent replication
+            // source iterator (which read up to consistentTimestamp) to reach the end of the log when the
+            // consistentTimestamp is updated.
+            consistentTimestamp = Some(tx.timestamp)
+
+            // Check for more consistent transaction
             checkPendingConsistency()
           }
         }

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/TestTransactionRecorder.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/TestTransactionRecorder.scala
@@ -246,10 +246,10 @@ class TestTransactionRecorder extends TestTransactionBase with BeforeAndAfter wi
     verify(txLogProxy.mockAppender).append(LogRecord(2000, Some(4), request7))
     verify(txLogProxy.mockAppender).append(LogRecord(3000, Some(5), createResponseMessage(request6)))
     verify(txLogProxy.mockAppender).append(LogRecord(3010, Some(6), createResponseMessage(request7)))
-    verify(txLogProxy.mockAppender).append(LogRecord(4000, Some(7), request8))
-    verify(txLogProxy.mockAppender).append(LogRecord(4010, Some(7), request9))
-    verify(txLogProxy.mockAppender).append(LogRecord(4020, Some(7), createResponseMessage(request9)))
-    verify(txLogProxy.mockAppender).append(LogRecord(4030, Some(7), createResponseMessage(request8)))
+    verify(txLogProxy.mockAppender).append(LogRecord(4000, Some(6), request8))
+    verify(txLogProxy.mockAppender).append(LogRecord(4010, Some(6), request9))
+    verify(txLogProxy.mockAppender).append(LogRecord(4020, Some(6), createResponseMessage(request9)))
+    verify(txLogProxy.mockAppender).append(LogRecord(4030, Some(6), createResponseMessage(request8)))
     txLogProxy.verifyNoMoreInteractions()
   }
 }


### PR DESCRIPTION
There was a race in the implementation. The Index was appended with the new consistent timestamp before the new consistent timestamp was made visible externaly. Requests and responses appended between appendIndex and the visible update of the consistentTimestamp where using the previous consistent timestamp.

The call inversion (i.e. append with new consistent timestamp before making it externaly visible) was a workaround to prevent TransactionLogReplicationIterator to read beyond the end of the log file (the replication source skips Index record and the iterator read one record ahead).

Both problems (i.e. the race and reading beyond eof) are resolved by simply never appending an Index in the recorder.
