### PR TITLE
Fallback to slower consistency verification when store timestamp < log timestamp

### DIFF
--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/TestTransactionRecorder.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/TestTransactionRecorder.scala
@@ -14,7 +14,7 @@ import org.scalatest.matchers.ShouldMatchers._
 import com.wajam.nrv.utils.IdGenerator
 import org.scalatest.mock.MockitoSugar
 import persistence.LogRecord.Index
-import persistence.LogRecord
+import com.wajam.nrv.consistency.persistence.{TransactionLogProxy, LogRecord}
 import com.wajam.nrv.utils.timestamp.Timestamp
 
 @RunWith(classOf[JUnitRunner])

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/persistence/TestTransactionLog.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/persistence/TestTransactionLog.scala
@@ -1,0 +1,149 @@
+package com.wajam.nrv.consistency.persistence
+
+import com.wajam.nrv.consistency.TestTransactionBase
+import com.wajam.nrv.consistency.persistence.LogRecord.{Response, Index}
+import org.scalatest.matchers.ShouldMatchers._
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class TestTransactionLog extends TestTransactionBase with MockitoSugar {
+
+  class MockTransactionLogIterator(records: LogRecord*) extends TransactionLogIterator {
+    var closeCount = 0
+    val itr = records.toIterator
+
+    def hasNext = itr.hasNext
+
+    def next() = itr.next()
+
+    def close() {
+      closeCount += 1
+    }
+  }
+
+  test("first timestamped record should returns expected record") {
+    val expectedRequest = LogRecord(id = 100, None, createRequestMessage(timestamp = 100))
+    val iterator = new MockTransactionLogIterator(expectedRequest)
+
+    val txLogProxy = new TransactionLogProxy
+    when(txLogProxy.mockTxLog.read(100L)).thenReturn(iterator)
+
+    iterator.closeCount should be(0)
+    txLogProxy.firstRecord(Some(100L)) should be(Some(expectedRequest))
+    iterator.closeCount should be(1)
+  }
+
+  test("first timestamped record should returns expected response record") {
+    val expectedResponse = LogRecord(id = 100, None, createResponseMessage(createRequestMessage(timestamp = 100)))
+    val iterator = new MockTransactionLogIterator(expectedResponse)
+
+    val txLogProxy = new TransactionLogProxy
+    when(txLogProxy.mockTxLog.read(100L)).thenReturn(iterator)
+
+    iterator.closeCount should be(0)
+    txLogProxy.firstRecord(Some(100L)) should be(Some(expectedResponse))
+    iterator.closeCount should be(1)
+  }
+
+  test("first timestamped record called with None should returns expected record") {
+    val expectedRequest = LogRecord(id = 100, None, createRequestMessage(timestamp = 100))
+    val iterator = new MockTransactionLogIterator(expectedRequest)
+
+    val txLogProxy = new TransactionLogProxy
+    when(txLogProxy.mockTxLog.read(Index(Long.MinValue))).thenReturn(iterator)
+
+    iterator.closeCount should be(0)
+    txLogProxy.firstRecord(None) should be(Some(expectedRequest))
+    iterator.closeCount should be(1)
+  }
+
+  test("first timestamped record should skip index") {
+    val expectedRequest = LogRecord(id = 100, None, createRequestMessage(timestamp = 100))
+    val iterator = new MockTransactionLogIterator(Index(0L), expectedRequest)
+
+    val txLogProxy = new TransactionLogProxy
+    when(txLogProxy.mockTxLog.read(100L)).thenReturn(iterator)
+
+    iterator.closeCount should be(0)
+    txLogProxy.firstRecord(Some(100L)) should be(Some(expectedRequest))
+    iterator.closeCount should be(1)
+  }
+
+  test("first timestamped record should not fail when log is empty") {
+    val iterator = new MockTransactionLogIterator()
+
+    val txLogProxy = new TransactionLogProxy
+    when(txLogProxy.mockTxLog.read(100L)).thenReturn(iterator)
+
+    iterator.closeCount should be(0)
+    txLogProxy.firstRecord(Some(100L)) should be(None)
+    iterator.closeCount should be(1)
+  }
+
+  test("first timestamped record should not fail when log only contains index") {
+    val iterator = new MockTransactionLogIterator(Index(0L), Index(1L))
+
+    val txLogProxy = new TransactionLogProxy
+    when(txLogProxy.mockTxLog.read(100L)).thenReturn(iterator)
+
+    iterator.closeCount should be(0)
+    txLogProxy.firstRecord(Some(100L)) should be(None)
+    iterator.closeCount should be(1)
+  }
+
+  test("last successful ts should returns expected timestamp") {
+    val response1 = Response(100, None, 100L, 0, Response.Success)
+    val response2 = Response(200, None, 200L, 0, Response.Success)
+    val response3 = Response(300, None, 300L, 0, Response.Success)
+    val iterator = new MockTransactionLogIterator(response2, response3, response1)
+
+    val txLogProxy = new TransactionLogProxy
+    when(txLogProxy.mockTxLog.read(100L)).thenReturn(iterator)
+
+    iterator.closeCount should be(0)
+    txLogProxy.lastSuccessfulTimestamp(100L) should be(Some(response3.timestamp))
+    iterator.closeCount should be(1)
+  }
+
+  test("last successful ts should ignore error response") {
+    val response1 = Response(100, None, 100L, 0, Response.Success)
+    val response2 = Response(200, None, 200L, 0, Response.Success)
+    val response3 = Response(300, None, 300L, 0, Response.Error)
+    val iterator = new MockTransactionLogIterator(response2, response3, response1)
+
+    val txLogProxy = new TransactionLogProxy
+    when(txLogProxy.mockTxLog.read(100L)).thenReturn(iterator)
+
+    iterator.closeCount should be(0)
+    txLogProxy.lastSuccessfulTimestamp(100L) should be(Some(response2.timestamp))
+    iterator.closeCount should be(1)
+  }
+
+  test("last successful ts should not fail if log is empty") {
+    val iterator = new MockTransactionLogIterator()
+
+    val txLogProxy = new TransactionLogProxy
+    when(txLogProxy.mockTxLog.read(100L)).thenReturn(iterator)
+
+    iterator.closeCount should be(0)
+    txLogProxy.lastSuccessfulTimestamp(100L) should be(None)
+    iterator.closeCount should be(1)
+  }
+
+  test("last successful ts should not fail if log does not contains success response") {
+    val request = LogRecord(id = 100, None, createRequestMessage(timestamp = 100))
+    val response = Response(100, None, 100L, 0, Response.Error)
+    val index = Index(300, Some(100L))
+    val iterator = new MockTransactionLogIterator(request, response, index)
+
+    val txLogProxy = new TransactionLogProxy
+    when(txLogProxy.mockTxLog.read(100L)).thenReturn(iterator)
+
+    iterator.closeCount should be(0)
+    txLogProxy.lastSuccessfulTimestamp(100L) should be(None)
+    iterator.closeCount should be(1)
+  }
+}

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/persistence/TransactionLogProxy.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/persistence/TransactionLogProxy.scala
@@ -1,12 +1,10 @@
-package com.wajam.nrv.consistency
+package com.wajam.nrv.consistency.persistence
 
-import persistence.LogRecord.Index
-import persistence.{LogRecord, TransactionLog}
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
+import com.wajam.nrv.consistency.persistence.LogRecord.Index
 import com.wajam.nrv.utils.timestamp.Timestamp
 import org.mockito.Mockito
-
 
 trait TransactionAppender {
   def append(record: LogRecord)

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestReplicationSubscriber.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestReplicationSubscriber.scala
@@ -8,14 +8,14 @@ import org.mockito.Matchers._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import com.wajam.nrv.service._
-import com.wajam.nrv.consistency.{TestTransactionBase, TransactionLogProxy, ResolvedServiceMember, ConsistentStore}
+import com.wajam.nrv.consistency.{TestTransactionBase, ResolvedServiceMember, ConsistentStore}
 import com.wajam.nrv.data._
 import com.wajam.nrv.utils.timestamp.Timestamp
 import MessageMatcher._
 import com.wajam.nrv.consistency.persistence.LogRecord.Index
 import java.util.UUID
 import com.wajam.nrv.utils.IdGenerator
-import com.wajam.nrv.consistency.persistence.LogRecord
+import com.wajam.nrv.consistency.persistence.{TransactionLogProxy, LogRecord}
 
 @RunWith(classOf[JUnitRunner])
 class TestReplicationSubscriber extends TestTransactionBase with BeforeAndAfter with MockitoSugar {


### PR DESCRIPTION
In this situation there is a possibility that the last transaction log consistent timestamp is an uncommitted transaction (i.e. response not written successfully in storage). We must compare the timestamp of the last committed transaction in this situation.

Fix #189
