### PR TITLE
Removed unsafe usage of ResolvedServiceMember in actor catch

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
@@ -678,7 +678,7 @@ class ConsistencyMasterSlave(val timestampGenerator: TimestampGenerator, txLogDi
               subscribe(member, mode)
             } catch {
               case e: Exception => {
-                warn("Error processing subscribe for {}", ResolvedServiceMember(service, member), e)
+                warn("Error processing subscribe for {}", member, e)
               }
             }
           }
@@ -687,7 +687,7 @@ class ConsistencyMasterSlave(val timestampGenerator: TimestampGenerator, txLogDi
               replicationSubscriber.unsubscribe(ResolvedServiceMember(service, member))
             } catch {
               case e: Exception => {
-                warn("Error processing unsubscribe for {}", ResolvedServiceMember(service, member), e)
+                warn("Error processing unsubscribe for {}", member, e)
               }
             }
           }


### PR DESCRIPTION
If subscribe/unsubscribe failed due to service member migration or cluster stop, using ResolvedServiceMember can fail to resolve the service member and prematuraly kill the  ResolvedServiceMember. The actor wait foreever the Kill message will be send later, freezing the server.
