### PR TITLE
Ability to specify the timestamp generator timeout extra delay

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
@@ -34,12 +34,10 @@ import com.wajam.nrv.service.StatusTransitionEvent
  * - The messages for a given token are sequenced before reaching the consistency manager.
  * - Messages timestamps are unique in the whole cluster and also sequenced per message token.
  *
- * IMPORTANT NOTES:
- * - This class is still a work in progress.
- * - Support binding to a single service. The service must extends ConsistentStore.
  */
 class ConsistencyMasterSlave(val timestampGenerator: TimestampGenerator, txLogDir: String, txLogEnabled: Boolean,
                              txLogRolloverSize: Int = 50000000, txLogCommitFrequency: Int = 5000,
+                             timestampTimeoutExtraDelay: Int = 250,
                              replicationTps: Int = 50, replicationWindowSize: Int = 20,
                              replicationSubscriptionIdleTimeout: Long = 30000L, replicationSubscribeDelay: Long = 5000,
                              replicationResolver: Option[Resolver] = None)
@@ -332,7 +330,7 @@ class ConsistencyMasterSlave(val timestampGenerator: TimestampGenerator, txLogDi
           }
           val member = ResolvedServiceMember(service, event.member)
           val recorder = new TransactionRecorder(member, txLog,
-            consistencyDelay = timestampGenerator.responseTimeout + 1000,
+            consistencyDelay = timestampGenerator.responseTimeout + timestampTimeoutExtraDelay,
             consistencyTimeout = math.max(service.responseTimeout + 2000, 15000),
             commitFrequency = txLogCommitFrequency, onConsistencyError = {
               metrics.consistencyError.mark()


### PR DESCRIPTION
This timeout extra delay is used to compute the consistency delay. After the consistency delay, a transaction is flag as consistent i.e. we have seen all the transactions up the transaction timestamp. The timeout extra delay is a buffer to process the timestamp generator timeout response.
