### PR TITLE
Temporary rollback TransactionLogReplicationIterator

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/TransactionLogReplicationIterator.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/TransactionLogReplicationIterator.scala
@@ -1,6 +1,6 @@
 package com.wajam.nrv.consistency.replication
 
-import com.wajam.nrv.consistency.persistence.{LogRecord, TransactionLogIterator, TimestampedRecord, TransactionLog}
+import com.wajam.nrv.consistency.persistence.{TransactionLogIterator, TimestampedRecord, TransactionLog}
 import com.wajam.nrv.utils.timestamp.Timestamp
 import collection.immutable.TreeMap
 import com.wajam.nrv.consistency.persistence.LogRecord.{Index, Response, Request}
@@ -10,20 +10,20 @@ import com.yammer.metrics.scala.Instrumented
 /**
  * Replication source iterator backed by a transaction log. The transactions are ordered by timestamp. This iterator
  * only returns successful transactions. The iterator does not returns transactions beyond the current consistent
- * timestamp. If more records are available beyond current consistent timestamp, the iterator hasMore() continue
+ * timestamp. If more records are available * beyond current consistent timestamp, the iterator hasMore() continue
  * to return true but next() returns None. New transactions will be returned if new records are written to the
  * log and the current consistent timestamp advance. If the consistent timestamp advance beyond the end of the log,
  * the iterator is closed and hasNext() returns false.
  * <p><p>
- * This class is not thread safe and must invoked from a single thread or synchronized externally.
+ * This class is not thread safe and must invoked from a single thread or synchronized externaly.
  */
 class TransactionLogReplicationIterator(member: ResolvedServiceMember, val start: Timestamp,
                                         txLog: TransactionLog, currentConsistentTimestamp: => Option[Timestamp],
-                                        isDraining: => Boolean = false)
+                                        mustDrain: => Boolean = false)
   extends ReplicationSourceIterator with Instrumented {
 
   val end = None
-  private var lastReadRecord: Option[LogRecord] = None
+  private var lastReadRecord: Option[TimestampedRecord] = None
   private var pendingTransactions: TreeMap[Timestamp, PendingTransaction] = TreeMap()
   private val itr = initLogIterator()
   private var lastTxTimestamp: Option[Long] = None
@@ -39,8 +39,7 @@ class TransactionLogReplicationIterator(member: ResolvedServiceMember, val start
 
   def hasNext = {
     readMoreLogRecords()
-    itr.hasNext || (!isDraining && lastRecordIsIndexAtCurrentConsistentTimestamp) ||
-      (isDraining && pendingTransactions.nonEmpty)
+    itr.hasNext || mustDrain && pendingTransactions.nonEmpty
   }
 
   def next() = {
@@ -78,45 +77,37 @@ class TransactionLogReplicationIterator(member: ResolvedServiceMember, val start
    * the last read record consistent timestamp.
    */
   private def isHeadTransactionReady: Boolean = {
-    if (isDraining && !itr.hasNext && pendingTransactions.nonEmpty) {
+    if (mustDrain && !itr.hasNext && pendingTransactions.nonEmpty) {
       true
     } else {
       val ready = for {
         (_, tx) <- pendingTransactions.headOption
         headResponse <- tx.response
-        maxTimestamp <- currentConsistentTimestamp
+        lastRecord <- lastReadRecord
+        maxTimestamp <- lastRecord.consistentTimestamp
       } yield headResponse.timestamp <= maxTimestamp
       ready.getOrElse(false)
-    }
-  }
-
-  private def lastRecordIsIndexAtCurrentConsistentTimestamp: Boolean = {
-    lastReadRecord match {
-      case Some(lastIndex: Index) => lastIndex.consistentTimestamp == currentConsistentTimestamp
-      case _ => false
     }
   }
 
   /**
    * Returns true if the last read record timestamp is not beyond the current consistent timestamp
    */
-  private def lastRecordIsBeforeOrEqualsToCurrentConsistentTimestamp(indexCanEqualsConsistentTimestamp: Boolean): Boolean = {
-    (currentConsistentTimestamp, lastReadRecord) match {
-      case (Some(maxTimestamp), Some(lastRecord: TimestampedRecord)) if lastRecord.timestamp <= maxTimestamp => true
-      case (Some(maxTimestamp), Some(Index(_, Some(lastIndexConsistentTimestamp)))) => {
-        lastIndexConsistentTimestamp < maxTimestamp ||
-          (indexCanEqualsConsistentTimestamp && lastIndexConsistentTimestamp == maxTimestamp)
-      }
-      case _ => false
-    }
+  private def isLastRecordBeforeCurrentConsistentTimestamp: Boolean = {
+    val before = for {
+      maxTimestamp <- currentConsistentTimestamp
+      lastRecord <- lastReadRecord
+    } yield lastRecord.timestamp < maxTimestamp
+    before.getOrElse(false)
   }
 
+  private def isLastRecordEqualsToConsistentTimestamp = lastReadRecord.map(_.timestamp) == currentConsistentTimestamp
+
   private def readMoreLogRecords() {
-    // Read records until the head transaction is ready (see definition above) but never going beyond the the current
+    // Read records untill the head transaction is ready (see definition above) but never going beyond the the current
     // consistent timestamp.
-    while (itr.hasNext && (lastReadRecord.isEmpty || !isHeadTransactionReady &&
-      (isDraining && lastRecordIsBeforeOrEqualsToCurrentConsistentTimestamp(indexCanEqualsConsistentTimestamp = true) ||
-        lastRecordIsBeforeOrEqualsToCurrentConsistentTimestamp(indexCanEqualsConsistentTimestamp = false)))) {
+    while (itr.hasNext && (lastReadRecord.isEmpty ||
+      (isLastRecordBeforeCurrentConsistentTimestamp || mustDrain && isLastRecordEqualsToConsistentTimestamp) && !isHeadTransactionReady)) {
       val record = itr.next()
       record match {
         case request: Request => {
@@ -127,7 +118,7 @@ class TransactionLogReplicationIterator(member: ResolvedServiceMember, val start
           pendingTransactions(response.timestamp).response = Some(response)
           lastReadRecord = Some(response)
         }
-        case index: Index => lastReadRecord = Some(index)
+        case index: Index => // Just skip index
       }
     }
   }
@@ -153,7 +144,6 @@ class TransactionLogReplicationIterator(member: ResolvedServiceMember, val start
         new TransactionLogIterator {
           val filteredItr = rawItr.withFilter(_ match {
             case r: TimestampedRecord if r.timestamp >= record.timestamp => true
-            case i: Index => true
             case _ => false
           })
 
@@ -167,7 +157,7 @@ class TransactionLogReplicationIterator(member: ResolvedServiceMember, val start
         }
       }
       case None => {
-        // No starting record, read log from the beginning
+        // No starting record, read log from the begining
         txLog.read(Index(Long.MinValue))
       }
     }

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestMasterReplicationSessionManager.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestMasterReplicationSessionManager.scala
@@ -536,7 +536,7 @@ class TestMasterReplicationSessionManager extends TestTransactionBase with Befor
     reset(mockSlaveReplicateTxAction)
     currentConsistentTimestamp = Some(8L)
     verify(mockSlaveReplicateTxAction, timeout(1500).times(1)).callOutgoingHandlers(messageCaptor.capture())
-    messageCaptor.getValue.getData[Message].timestamp should be(Some(Timestamp(8L)))
+    messageCaptor.getValue.getData[Message].timestamp should be(Some(Timestamp(7L)))
     verifyNoMoreInteractionsAfter(wait = 100, mockSlaveReplicateTxAction)
   }
 
@@ -555,8 +555,8 @@ class TestMasterReplicationSessionManager extends TestTransactionBase with Befor
     session.endTimestamp should be(None)
 
     val allexpectedTxMessages = toTransactionMessages(allLogRecords, startTimestamp)
-    val (expectedTxMessages, newExpectedTxMessages) = allexpectedTxMessages.partition(
-      _.getData[Message].timestamp.get <= logRecords.last.consistentTimestamp.get.value)
+    val (expectedTxMessages, newexpectedTxMessages) = allexpectedTxMessages.partition(
+      _.getData[Message].timestamp.get < logRecords.last.consistentTimestamp.get.value)
 
     val messageCaptor = ArgumentCaptor.forClass(classOf[OutMessage])
     verify(mockSlaveReplicateTxAction, timeout(1500).atLeast(expectedTxMessages.size)).callOutgoingHandlers(messageCaptor.capture())
@@ -572,9 +572,9 @@ class TestMasterReplicationSessionManager extends TestTransactionBase with Befor
     currentConsistentTimestamp = newLogRecords.last.consistentTimestamp
 
     val newMessageCaptor = ArgumentCaptor.forClass(classOf[OutMessage])
-    verify(mockSlaveReplicateTxAction, timeout(1500).atLeast(newExpectedTxMessages.size)).callOutgoingHandlers(newMessageCaptor.capture())
-    assertReplicationMessagesEquals(newMessageCaptor.getAllValues.filter(_.hasData), newExpectedTxMessages,
-      size = newExpectedTxMessages.size, ignoreSequence = true)
+    verify(mockSlaveReplicateTxAction, timeout(1500).atLeast(newexpectedTxMessages.size)).callOutgoingHandlers(newMessageCaptor.capture())
+    assertReplicationMessagesEquals(newMessageCaptor.getAllValues.filter(_.hasData), newexpectedTxMessages,
+      size = newexpectedTxMessages.size - 1, ignoreSequence = true)
 
     verifyNoMoreInteractionsAfter(wait = 100, mockSlaveReplicateTxAction)
   }

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestTransactionLogReplicationIterator.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestTransactionLogReplicationIterator.scala
@@ -40,7 +40,7 @@ class TestTransactionLogReplicationIterator extends TestTransactionBase with Bef
   }
 
   test("empty log should not fail") {
-    val itr = new TransactionLogReplicationIterator(member, start = 1L, txLog, Some(Long.MaxValue), isDraining = false)
+    val itr = new TransactionLogReplicationIterator(member, start = 1L, txLog, Some(Long.MaxValue), mustDrain = false)
     itr.hasNext should be(false)
   }
 
@@ -79,24 +79,24 @@ class TestTransactionLogReplicationIterator extends TestTransactionBase with Bef
       itr.take(takeCount).flatten.map(msg => msg.timestamp).flatten.map(ts => ts.value).toList
     }
 
-    val from1 = new TransactionLogReplicationIterator(member, start = 1L, txLog, currentConsistentTimestamp, isDraining = false)
+    val from1 = new TransactionLogReplicationIterator(member, start = 1L, txLog, currentConsistentTimestamp, mustDrain = false)
     takeTimestamps(from1, consistentTimestamp = None, 100) should be(List())
     takeTimestamps(from1, consistentTimestamp = Some(1), 100) should be(List())
     takeTimestamps(from1, consistentTimestamp = Some(5), 100) should be(List(1L))
     takeTimestamps(from1, consistentTimestamp = Some(5), 100) should be(List())
-    takeTimestamps(from1, consistentTimestamp = Some(7), 100) should be(List(2L, 4L, 5L, 6L, 7L))
+    takeTimestamps(from1, consistentTimestamp = Some(7), 100) should be(List(2L, 4L, 5L, 6L))
     takeTimestamps(from1, consistentTimestamp = Some(7), 100) should be(List())
-    takeTimestamps(from1, consistentTimestamp = Some(8), 100) should be(List(8L))
+    takeTimestamps(from1, consistentTimestamp = Some(8), 100) should be(List(7L))
     takeTimestamps(from1, consistentTimestamp = Some(8), 100) should be(List())
 
-    val from3 = new TransactionLogReplicationIterator(member, start = 3L, txLog, currentConsistentTimestamp, isDraining = false)
+    val from3 = new TransactionLogReplicationIterator(member, start = 3L, txLog, currentConsistentTimestamp, mustDrain = false)
     takeTimestamps(from3, consistentTimestamp = None, 100) should be(List())
-    takeTimestamps(from3, consistentTimestamp = Some(8), 100) should be(List(4L, 5L, 6L, 7L, 8L))
+    takeTimestamps(from3, consistentTimestamp = Some(8), 100) should be(List(4L, 5L, 6L, 7L))
     takeTimestamps(from3, consistentTimestamp = Some(8), 100) should be(List())
 
-    val from6 = new TransactionLogReplicationIterator(member, start = 6L, txLog, currentConsistentTimestamp, isDraining = false)
+    val from6 = new TransactionLogReplicationIterator(member, start = 6L, txLog, currentConsistentTimestamp, mustDrain = false)
     takeTimestamps(from6, consistentTimestamp = None, 100) should be(List())
-    takeTimestamps(from6, consistentTimestamp = Some(8), 100) should be(List(6L, 7L, 8L))
+    takeTimestamps(from6, consistentTimestamp = Some(8), 100) should be(List(6L, 7L))
     takeTimestamps(from6, consistentTimestamp = Some(8), 100) should be(List())
 
     // Append more records and read them
@@ -104,11 +104,11 @@ class TestTransactionLogReplicationIterator extends TestTransactionBase with Bef
     txLog.append(LogRecord(1010, Some(8), createResponseMessage(request9)))
     txLog.append(Index(1020, Some(9)))
 
-    takeTimestamps(from1, consistentTimestamp = Some(9), 100) should be(List(9L))
+    takeTimestamps(from1, consistentTimestamp = Some(9), 100) should be(List(8L))
     from1.hasNext should be(true)
-    takeTimestamps(from3, consistentTimestamp = Some(9), 100) should be(List(9L))
+    takeTimestamps(from3, consistentTimestamp = Some(9), 100) should be(List(8L))
     from3.hasNext should be(true)
-    takeTimestamps(from6, consistentTimestamp = Some(9), 100) should be(List(9L))
+    takeTimestamps(from6, consistentTimestamp = Some(9), 100) should be(List(8L))
     from6.hasNext should be(true)
 
     // Try read beyond the end of log
@@ -121,12 +121,12 @@ class TestTransactionLogReplicationIterator extends TestTransactionBase with Bef
 
     // Missing timestamp
     evaluating {
-      new TransactionLogReplicationIterator(member, start = -1L, txLog, None, isDraining = false)
+      new TransactionLogReplicationIterator(member, start = -1L, txLog, None, mustDrain = false)
     } should produce[NoSuchElementException]
   }
 
   /**
-   * This test append and read new log records concurrently from two threads and ensure that the iterator is not closed
+   * This test append and read new log records concurently from two threads and ensure that the iterator is not closed
    * when log rolls.
    */
   test("iterator not closed on log roll") {
@@ -136,8 +136,7 @@ class TestTransactionLogReplicationIterator extends TestTransactionBase with Bef
     // This make the test more deterministic and the time management does not requires any sleep.
     var consistencyErrorCount = 0
     var currentId = 0L
-    val consistencyDelay = 500L
-    val recorder = new TransactionRecorder(member, txLog, consistencyDelay, consistencyTimeout = 5000L,
+    val recorder = new TransactionRecorder(member, txLog, consistencyDelay = 500L, consistencyTimeout = 5000L,
       commitFrequency = 0, onConsistencyError = consistencyErrorCount += 1,
       idGenerator = new IdGenerator[Long] {
         def nextId = currentId
@@ -158,7 +157,7 @@ class TestTransactionLogReplicationIterator extends TestTransactionBase with Bef
     appendMessage(request1)
     appendMessage(createResponseMessage(request1))
 
-    // Appender which append transaction until reaching a maximum count. The consumer is concurrently reading the
+    // Appender which append transaction until reaching a maximum count. The consumer is concurently reading the
     // transaction log as they are appended.
     val maxTxCount = 200
     val appender = Future {
@@ -185,24 +184,18 @@ class TestTransactionLogReplicationIterator extends TestTransactionBase with Bef
     while (recorder.currentConsistentTimestamp == None) {}
 
     // Consumer is reading from the transaction log while new transaction are added by the appender until the appender
-    // completed and the consumer read last record respecting the last appended record consistent timestamp.
+    // completed and the consumer read last record repecting the last appended record consistent timestamp.
     val consumer = Future {
       val itr = new TransactionLogReplicationIterator(member, start = request1.timestamp.get,
-        txLog, recorder.currentConsistentTimestamp, isDraining = false)
+        txLog, recorder.currentConsistentTimestamp, mustDrain = false)
 
-      def finalConsistentRecord = {
-        txLog.getLastLoggedRecord.collectFirst {
-          case i: Index if i.consistentTimestamp == recorder.currentConsistentTimestamp => i
-        }
-      }
+      def finalConsistentRecord = txLog.firstRecord(txLog.getLastLoggedRecord.get.consistentTimestamp)
 
       def isFinalTx(txOpt: Option[Message]) = {
-        if (appender.isCompleted) {
-          (txOpt, finalConsistentRecord) match {
-            case (Some(tx), Some(finalRecord)) => tx.timestamp == finalRecord.consistentTimestamp
-            case _ => false
-          }
-        } else false
+        txOpt match {
+          case Some(tx) if appender.isCompleted => tx.timestamp == finalConsistentRecord.get.consistentTimestamp
+          case _ => false
+        }
       }
 
       // Consume until end of iterator (not expected) or the final transaction is consumed.
@@ -224,12 +217,11 @@ class TestTransactionLogReplicationIterator extends TestTransactionBase with Bef
     // Wait for the appender and consumer to complete
     val appendedCount = Future.blocking(appender, 5000L)
     appendedCount should be >= maxTxCount
-    // Update current timestamp past consistency delay to ensure a final Index record is appended
-    currentId = appendedCount * 2 * 10 + consistencyDelay
 
-    // Consume all appended transactions
     val lastConsumed = Future.blocking(consumer, 5000L)
-    lastConsumed.get.timestamp should be(Some(Timestamp(appendedCount)))
+    val expectedLastTx = txLog.firstRecord(txLog.getLastLoggedRecord.get.consistentTimestamp)
+    expectedLastTx should not be None
+    lastConsumed.get.timestamp should be(expectedLastTx.get.consistentTimestamp)
 
     consistencyErrorCount should be(0)
   }
@@ -253,24 +245,27 @@ class TestTransactionLogReplicationIterator extends TestTransactionBase with Bef
     var draining = false
     var currentConsistentTimestamp: Option[Timestamp] = Some(3L)
 
-    val itr = new TransactionLogReplicationIterator(member, start = 1L, txLog, currentConsistentTimestamp, isDraining = draining)
-    itr.hasNext should be(true)
-    itr.next().flatMap(_.timestamp) should be(Some(Timestamp(1L)))
-    itr.hasNext should be(true)
-    itr.next().flatMap(_.timestamp) should be(Some(Timestamp(2L)))
-    itr.hasNext should be(true)
-    itr.next().flatMap(_.timestamp) should be(Some(Timestamp(3L)))
-    itr.hasNext should be(true)
+    val itr = new TransactionLogReplicationIterator(member, start = 1L, txLog, currentConsistentTimestamp, mustDrain = draining)
+    itr.hasNext should be (true)
+    itr.next().flatMap(_.timestamp) should be (Some(Timestamp(1L)))
+    itr.hasNext should be (true)
+    itr.next().flatMap(_.timestamp) should be (Some(Timestamp(2L)))
+    itr.hasNext should be (true)
+    itr.next() should be (None)
+
+    // Verify consistent timestamp is returned when draining
+    draining = true
+    itr.hasNext should be (true)
+    itr.next().flatMap(_.timestamp) should be (Some(Timestamp(3L)))
 
     // Verify not reading beyond consistent timestamp even when draining
-    draining = true
-    itr.hasNext should be(true)
-    itr.next() should be(None)
+    itr.hasNext should be (true)
+    itr.next() should be (None)
 
     // Verify iterator is closed when draining AND last record timestamp IS the consistent timestamp
     currentConsistentTimestamp = Some(4L)
-    itr.hasNext should be(true)
-    itr.next().flatMap(_.timestamp) should be(Some(Timestamp(4L)))
-    itr.hasNext should be(false)
+    itr.hasNext should be (true)
+    itr.next().flatMap(_.timestamp) should be (Some(Timestamp(4L)))
+    itr.hasNext should be (false)
   }
 }


### PR DESCRIPTION
I found that some records are replicated out of order. Rollbacking to the previous log replication reading strategy until the problem is fix.
