### PR TITLE
HTTP protocol do not use host header anymore as service name

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/protocol/HttpProtocol.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/protocol/HttpProtocol.scala
@@ -50,7 +50,6 @@ class HttpProtocol(name: String,
       case req: HttpRequest => {
         msg.protocolName = name
         msg.method = req.getMethod.getName
-        msg.serviceName = HttpHeaders.getHost(req, "")
         msg.path = new URI(req.getUri).getPath
         msg.attachments(HttpProtocol.KEEP_ALIVE_KEY) = isKeepAlive(req)
         msg.code = if (req.getHeader(HttpProtocol.CODE_HEADER) != null) {

--- a/nrv-core/src/main/scala/com/wajam/nrv/protocol/Protocol.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/protocol/Protocol.scala
@@ -55,7 +55,12 @@ abstract class Protocol(val name: String,
       val optAction = resolveAction(message.serviceName, message.actionURL.path, message.method)
 
       optAction match {
-        case Some(foundAction) => foundAction.callIncomingHandlers(message)
+        case Some(foundAction) => {
+          if (message.serviceName.isEmpty) {
+            message.serviceName = foundAction.service.name
+          }
+          foundAction.callIncomingHandlers(message)
+        }
         case None =>
           error("Couldn't find services/action for received message {}", message)
           throw new RouteException("No route found for received message " + message.toString)


### PR DESCRIPTION
When Protocol resolve incomming message target action, if the message service name is not already defined, it set it to the action service name.
