### PR TITLE
Rename nrv.consistency.persistence to nrv.consistency.log

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
@@ -5,7 +5,7 @@ import com.wajam.nrv.data._
 import com.wajam.nrv.utils.timestamp.{Timestamp, TimestampGenerator}
 import com.yammer.metrics.scala.{Meter, Instrumented}
 import com.wajam.nrv.utils.Event
-import com.wajam.nrv.consistency.persistence.{LogRecordSerializer, NullTransactionLog, FileTransactionLog}
+import com.wajam.nrv.consistency.log.{LogRecordSerializer, NullTransactionLog, FileTransactionLog}
 import java.util.concurrent.TimeUnit
 import com.yammer.metrics.core.Gauge
 import com.wajam.nrv.UnavailableException

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyRecovery.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyRecovery.scala
@@ -1,7 +1,7 @@
 package com.wajam.nrv.consistency
 
-import persistence.LogRecord._
-import persistence._
+import com.wajam.nrv.consistency.log.LogRecord._
+import com.wajam.nrv.consistency.log._
 import com.wajam.nrv.utils.timestamp.Timestamp
 import java.io.File
 import com.wajam.nrv.utils.{TimestampIdGenerator, IdGenerator}

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/TransactionRecorder.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/TransactionRecorder.scala
@@ -2,8 +2,8 @@ package com.wajam.nrv.consistency
 
 import scala.actors.Actor
 import com.yammer.metrics.scala.Instrumented
-import persistence.LogRecord.{Request, Response, Index}
-import persistence.TransactionLog
+import com.wajam.nrv.consistency.log.LogRecord.{Request, Response, Index}
+import com.wajam.nrv.consistency.log.TransactionLog
 import com.wajam.nrv.data.{MessageType, Message}
 import com.wajam.nrv.utils.timestamp.Timestamp
 import com.wajam.nrv.utils.{IdGenerator, TimestampIdGenerator, CurrentTime, Scheduler}

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/CompositeTransactionLogIterator.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/CompositeTransactionLogIterator.scala
@@ -1,4 +1,4 @@
-package com.wajam.nrv.consistency.persistence
+package com.wajam.nrv.consistency.log
 
 import annotation.tailrec
 

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/LogRecord.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/LogRecord.scala
@@ -1,8 +1,8 @@
-package com.wajam.nrv.consistency.persistence
+package com.wajam.nrv.consistency.log
 
 import com.wajam.nrv.utils.timestamp.Timestamp
 import com.wajam.nrv.data.{MessageType, Message}
-import com.wajam.nrv.consistency.persistence.LogRecord.Response.Status
+import com.wajam.nrv.consistency.log.LogRecord.Response.Status
 import scala.language.implicitConversions
 
 sealed trait LogRecord {

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/LogRecordSerializer.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/LogRecordSerializer.scala
@@ -1,10 +1,10 @@
-package com.wajam.nrv.consistency.persistence
+package com.wajam.nrv.consistency.log
 
 import java.io._
 import com.wajam.nrv.utils.timestamp.Timestamp
 import scala.Some
 import com.wajam.nrv.data.Message
-import com.wajam.nrv.consistency.persistence.LogRecord.{Index, Response, Request}
+import com.wajam.nrv.consistency.log.LogRecord.{Index, Response, Request}
 import com.wajam.nrv.protocol.codec.{GenericJavaSerializeCodec, MessageJavaSerializeCodec, Codec}
 import LogRecordSerializer._
 
@@ -135,7 +135,7 @@ class LogRecordSerializer(dataCodec: Codec = DefaultDataCodec) {
   }
 }
 
-private[persistence] object LogRecordSerializer {
+private[log] object LogRecordSerializer {
   val MinMessageLen = 0
   val MaxMessageLen = 1000000
 

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/MessageProtobufCodec.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/MessageProtobufCodec.scala
@@ -1,4 +1,4 @@
-package com.wajam.nrv.consistency.persistence
+package com.wajam.nrv.consistency.log
 
 import com.wajam.nrv.protocol.codec.Codec
 import com.wajam.nrv.data.Message

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/NullTransactionLog.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/NullTransactionLog.scala
@@ -1,7 +1,7 @@
-package com.wajam.nrv.consistency.persistence
+package com.wajam.nrv.consistency.log
 
 import com.wajam.nrv.utils.timestamp.Timestamp
-import com.wajam.nrv.consistency.persistence.LogRecord.Index
+import com.wajam.nrv.consistency.log.LogRecord.Index
 
 object NullTransactionLog extends TransactionLog {
 

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/TransactionLog.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/TransactionLog.scala
@@ -1,7 +1,7 @@
-package com.wajam.nrv.consistency.persistence
+package com.wajam.nrv.consistency.log
 
 import com.wajam.nrv.utils.timestamp.Timestamp
-import com.wajam.nrv.consistency.persistence.LogRecord.{Response, Index}
+import com.wajam.nrv.consistency.log.LogRecord.{Response, Index}
 import com.wajam.nrv.utils.Closable
 
 trait TransactionLog {

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/MasterReplicationSessionManager.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/MasterReplicationSessionManager.scala
@@ -4,7 +4,7 @@ import com.wajam.nrv.service._
 import com.wajam.nrv.utils.timestamp.Timestamp
 import com.wajam.nrv.data._
 import com.wajam.nrv.consistency.{ConsistentStore, ResolvedServiceMember}
-import com.wajam.nrv.consistency.persistence.TransactionLog
+import com.wajam.nrv.consistency.log.TransactionLog
 import com.wajam.nrv.cluster.Node
 import com.wajam.nrv.utils.{CurrentTime, Scheduler, UuidStringGenerator}
 import scala.actors.Actor

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/SlaveReplicationSessionManager.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/SlaveReplicationSessionManager.scala
@@ -7,16 +7,16 @@ import com.wajam.nrv.utils.timestamp.Timestamp
 import scala.actors.Actor
 import com.wajam.nrv.utils._
 import collection.immutable.TreeSet
-import com.wajam.nrv.consistency.persistence.TransactionLog
+import com.wajam.nrv.consistency.log.TransactionLog
 import ReplicationAPIParams._
-import com.wajam.nrv.consistency.persistence.LogRecord.{Response, Request}
-import com.wajam.nrv.consistency.persistence.LogRecord.Response.Success
+import com.wajam.nrv.consistency.log.LogRecord.{Response, Request}
+import com.wajam.nrv.consistency.log.LogRecord.Response.Success
 import annotation.tailrec
 import com.wajam.nrv.{TimeoutException, Logging}
 import java.util.{TimerTask, Timer}
 import com.yammer.metrics.scala.Instrumented
 import util.Random
-import com.wajam.nrv.consistency.persistence.LogRecord.Index
+import com.wajam.nrv.consistency.log.LogRecord.Index
 
 /**
  * Manage all local slave replication sessions for a service. Only one replication session per

--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/TransactionLogReplicationIterator.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/replication/TransactionLogReplicationIterator.scala
@@ -1,9 +1,9 @@
 package com.wajam.nrv.consistency.replication
 
-import com.wajam.nrv.consistency.persistence.{LogRecord, TransactionLogIterator, TimestampedRecord, TransactionLog}
+import com.wajam.nrv.consistency.log.{LogRecord, TransactionLogIterator, TimestampedRecord, TransactionLog}
 import com.wajam.nrv.utils.timestamp.Timestamp
 import collection.immutable.TreeMap
-import com.wajam.nrv.consistency.persistence.LogRecord.{Index, Response, Request}
+import com.wajam.nrv.consistency.log.LogRecord.{Index, Response, Request}
 import com.wajam.nrv.consistency.ResolvedServiceMember
 import com.yammer.metrics.scala.Instrumented
 

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/TestConsistencyRecovery.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/TestConsistencyRecovery.scala
@@ -6,13 +6,12 @@ import org.scalatest.BeforeAndAfter
 import java.io.File
 import java.nio.file.Files
 import org.mockito.Mockito._
-import persistence.LogRecord.{Response, Request, Index}
-import persistence.FileTransactionLog
+import com.wajam.nrv.consistency.log.LogRecord.{Response, Request, Index}
+import com.wajam.nrv.consistency.log.FileTransactionLog
 import com.wajam.nrv.service.TokenRange
 import org.scalatest.mock.MockitoSugar
 import com.wajam.nrv.utils.IdGenerator
 import org.scalatest.matchers.ShouldMatchers._
-
 
 @RunWith(classOf[JUnitRunner])
 class TestConsistencyRecovery extends TestTransactionBase with BeforeAndAfter with MockitoSugar {

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/TestTransactionRecorder.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/TestTransactionRecorder.scala
@@ -13,8 +13,8 @@ import org.scalatest.matchers.ShouldMatchers._
 
 import com.wajam.nrv.utils.IdGenerator
 import org.scalatest.mock.MockitoSugar
-import persistence.LogRecord.Index
-import com.wajam.nrv.consistency.persistence.{TransactionLogProxy, LogRecord}
+import com.wajam.nrv.consistency.log.LogRecord.Index
+import com.wajam.nrv.consistency.log.{TransactionLogProxy, LogRecord}
 import com.wajam.nrv.utils.timestamp.Timestamp
 
 @RunWith(classOf[JUnitRunner])

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/log/TestCompositeTransactionLogIterator.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/log/TestCompositeTransactionLogIterator.scala
@@ -1,8 +1,8 @@
-package com.wajam.nrv.consistency.persistence
+package com.wajam.nrv.consistency.log
 
 import org.scalatest.matchers.ShouldMatchers._
 import org.mockito.Mockito._
-import com.wajam.nrv.consistency.persistence.LogRecord.Index
+import com.wajam.nrv.consistency.log.LogRecord.Index
 import com.wajam.nrv.consistency.TestTransactionBase
 import org.scalatest.mock.MockitoSugar
 

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/log/TestFileTransactionLog.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/log/TestFileTransactionLog.scala
@@ -1,4 +1,4 @@
-package com.wajam.nrv.consistency.persistence
+package com.wajam.nrv.consistency.log
 
 import org.scalatest.BeforeAndAfter
 import org.scalatest.matchers.ShouldMatchers._
@@ -10,9 +10,9 @@ import org.mockito.Mockito._
 import util.Random
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import com.wajam.nrv.consistency.persistence.LogRecord.Request
+import com.wajam.nrv.consistency.log.LogRecord.Request
 import com.wajam.nrv.consistency.TestTransactionBase
-import com.wajam.nrv.consistency.persistence.LogRecord.Index
+import com.wajam.nrv.consistency.log.LogRecord.Index
 
 @RunWith(classOf[JUnitRunner])
 class TestFileTransactionLog extends TestTransactionBase with BeforeAndAfter {

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/log/TestLogRecordSerializer.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/log/TestLogRecordSerializer.scala
@@ -1,4 +1,4 @@
-package com.wajam.nrv.consistency.persistence
+package com.wajam.nrv.consistency.log
 
 import org.scalatest.matchers.ShouldMatchers._
 import com.wajam.nrv.utils.timestamp.Timestamp
@@ -7,7 +7,7 @@ import util.Random
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import com.wajam.nrv.consistency.TestTransactionBase
-import com.wajam.nrv.consistency.persistence.LogRecord.{Response, Request}
+import com.wajam.nrv.consistency.log.LogRecord.{Response, Request}
 
 @RunWith(classOf[JUnitRunner])
 class TestLogRecordSerializer extends TestTransactionBase {

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/log/TestTransactionLog.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/log/TestTransactionLog.scala
@@ -1,7 +1,7 @@
-package com.wajam.nrv.consistency.persistence
+package com.wajam.nrv.consistency.log
 
 import com.wajam.nrv.consistency.TestTransactionBase
-import com.wajam.nrv.consistency.persistence.LogRecord.{Response, Index}
+import com.wajam.nrv.consistency.log.LogRecord.{Response, Index}
 import org.scalatest.matchers.ShouldMatchers._
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/log/TransactionLogProxy.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/log/TransactionLogProxy.scala
@@ -1,8 +1,8 @@
-package com.wajam.nrv.consistency.persistence
+package com.wajam.nrv.consistency.log
 
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
-import com.wajam.nrv.consistency.persistence.LogRecord.Index
+import com.wajam.nrv.consistency.log.LogRecord.Index
 import com.wajam.nrv.utils.timestamp.Timestamp
 import org.mockito.Mockito
 

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestMasterReplicationSessionManager.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestMasterReplicationSessionManager.scala
@@ -11,15 +11,15 @@ import com.wajam.nrv.consistency.{TestTransactionBase, ResolvedServiceMember, Co
 import com.wajam.nrv.data._
 import com.wajam.nrv.cluster.{Cluster, StaticClusterManager, Node, LocalNode}
 import java.io.File
-import com.wajam.nrv.consistency.persistence.{LogRecord, FileTransactionLog}
+import com.wajam.nrv.consistency.log.{LogRecord, FileTransactionLog}
 import java.nio.file.Files
 import com.wajam.nrv.utils.timestamp.Timestamp
 import org.mockito.Mockito._
-import com.wajam.nrv.consistency.persistence.LogRecord.{Response, Request}
+import com.wajam.nrv.consistency.log.LogRecord.{Response, Request}
 import org.mockito.ArgumentCaptor
 import scala.collection.JavaConversions._
 import com.wajam.nrv.utils.Closable
-import com.wajam.nrv.consistency.persistence.LogRecord.Index
+import com.wajam.nrv.consistency.log.LogRecord.Index
 import com.wajam.nrv.Logging
 
 @RunWith(classOf[JUnitRunner])

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestSlaveReplicationSessionManager.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestSlaveReplicationSessionManager.scala
@@ -13,10 +13,10 @@ import com.wajam.nrv.consistency.{TestTransactionBase, ResolvedServiceMember, Co
 import com.wajam.nrv.data._
 import com.wajam.nrv.utils.timestamp.Timestamp
 import MessageMatcher._
-import com.wajam.nrv.consistency.persistence.LogRecord.Index
+import com.wajam.nrv.consistency.log.LogRecord.Index
 import java.util.UUID
 import com.wajam.nrv.utils.IdGenerator
-import com.wajam.nrv.consistency.persistence.{TransactionLogProxy, LogRecord}
+import com.wajam.nrv.consistency.log.{TransactionLogProxy, LogRecord}
 
 @RunWith(classOf[JUnitRunner])
 class TestSlaveReplicationSessionManager extends TestTransactionBase with BeforeAndAfter with MockitoSugar {

--- a/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestTransactionLogReplicationIterator.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/consistency/replication/TestTransactionLogReplicationIterator.scala
@@ -5,10 +5,10 @@ import com.wajam.nrv.consistency.{TransactionRecorder, ResolvedServiceMember, Te
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import java.io.File
-import com.wajam.nrv.consistency.persistence.{LogRecord, FileTransactionLog}
+import com.wajam.nrv.consistency.log.{LogRecord, FileTransactionLog}
 import java.nio.file.Files
 import org.scalatest.matchers.ShouldMatchers._
-import com.wajam.nrv.consistency.persistence.LogRecord.Index
+import com.wajam.nrv.consistency.log.LogRecord.Index
 import com.wajam.nrv.utils.timestamp.Timestamp
 import com.wajam.nrv.service.TokenRange
 import com.wajam.nrv.utils.IdGenerator


### PR DESCRIPTION
I am about to add a new type of consistency persistence not related to transaction log and keeping the old consistency.persistence package name for transaction log is confusing and misleading.
