### PR TITLE
[NRV] Added resource utils for defining services that are designed as resources (REST style)

### DIFF
--- a/nrv-extension/src/main/scala/com/wajam/nrv/extension/resource/Resource.scala
+++ b/nrv-extension/src/main/scala/com/wajam/nrv/extension/resource/Resource.scala
@@ -20,6 +20,10 @@ class Resource(resourceName: String, idName: String, parent: Option[Resource] = 
  * to the specific operation trait.
  */
 sealed trait Operation {
+
+  /**
+   * Register the Resource operation to a Service.
+   */
   def registerTo(service: Service): Unit = {}
 }
 
@@ -32,76 +36,69 @@ sealed trait Operation {
 trait Get extends Operation {
   this: Resource =>
 
-  val getAction = new Action(pathWithId, (message: InMessage) => get(message), method = ActionMethod.GET)
+  def get(service: Service): Option[Action] = service.findAction(pathWithId, ActionMethod.GET)
 
   protected def get: (Request) => Unit
 
   abstract override def registerTo(service: Service): Unit = {
-    service.registerAction(getAction)
+    service.registerAction(new Action(pathWithId, (message: InMessage) => get(message), method = ActionMethod.GET))
     super.registerTo(service)
   }
 
-  def getAction(service: Service): Option[Action] = service.findAction(pathWithId, ActionMethod.GET)
 }
 
 trait List extends Operation {
   this: Resource =>
 
-  val listAction = new Action(path, (message: InMessage) => list(message), method = ActionMethod.GET)
+  def list(service: Service): Option[Action] = service.findAction(path, ActionMethod.GET)
 
   protected def list: (Request) => Unit
 
   abstract override def registerTo(service: Service): Unit = {
-    service.registerAction(listAction)
+    service.registerAction(new Action(path, (message: InMessage) => list(message), method = ActionMethod.GET))
     super.registerTo(service)
   }
-
-  def listAction(service: Service): Option[Action] = service.findAction(path, ActionMethod.GET)
 
 }
 
 trait Create extends Operation {
   this: Resource =>
 
-  val createAction = new Action(path, (message: InMessage) => create(message), method = ActionMethod.POST)
+  def create(service: Service): Option[Action] = service.findAction(path, ActionMethod.POST)
 
   protected def create: (Request) => Unit
 
   abstract override def registerTo(service: Service): Unit = {
-    service.registerAction(createAction)
+    service.registerAction(new Action(path, (message: InMessage) => create(message), method = ActionMethod.POST))
     super.registerTo(service)
   }
-
-  def createAction(service: Service): Option[Action] = service.findAction(path, ActionMethod.POST)
 
 }
 
 trait Update extends Operation {
   this: Resource =>
 
-  val updateAction = new Action(pathWithId, (message: InMessage) => update(message), method = ActionMethod.PUT)
+  def update(service: Service): Option[Action] = service.findAction(pathWithId, ActionMethod.PUT)
 
   protected def update: (Request) => Unit
 
   abstract override def registerTo(service: Service): Unit = {
-    service.registerAction(updateAction)
+    service.registerAction(new Action(pathWithId, (message: InMessage) => update(message), method = ActionMethod.PUT))
     super.registerTo(service)
   }
 
-  def updateAction(service: Service): Option[Action] = service.findAction(pathWithId, ActionMethod.PUT)
 }
 
 trait Delete extends Operation {
   this: Resource =>
 
-  val deleteAction = new Action(pathWithId, (message: InMessage) => delete(message), method = ActionMethod.DELETE)
+  def delete(service: Service): Option[Action] = service.findAction(pathWithId, ActionMethod.DELETE)
 
   protected def delete: (Request) => Unit
 
   abstract override def registerTo(service: Service): Unit = {
-    service.registerAction(deleteAction)
+    service.registerAction(new Action(pathWithId, (message: InMessage) => delete(message), method = ActionMethod.DELETE))
     super.registerTo(service)
   }
 
-  def deleteAction(service: Service): Option[Action] = service.findAction(pathWithId, ActionMethod.DELETE)
 }

--- a/nrv-extension/src/main/scala/com/wajam/nrv/extension/resource/package.scala
+++ b/nrv-extension/src/main/scala/com/wajam/nrv/extension/resource/package.scala
@@ -1,6 +1,6 @@
 package com.wajam.nrv.extension
 
-import com.wajam.nrv.service.Service
+import com.wajam.nrv.service.{Action, Service}
 import com.wajam.nrv.data._
 import com.wajam.nrv.data.MString
 import com.wajam.nrv.data.MList
@@ -34,15 +34,30 @@ package object resource {
       }
     }
 
-    def get(resource: Resource with Get) = resource.getAction(service).get
+    /**
+     * Retrieve the corresponding GET Action for the given resource registered to a given service.
+     */
+    def get(resource: Resource with Get): Option[Action] = resource.get(service)
 
-    def list(resource: Resource with List) = resource.listAction(service).get
+    /**
+     * Retrieve the corresponding LIST Action for the given resource registered to a given service.
+     */
+    def list(resource: Resource with List): Option[Action] = resource.list(service)
 
-    def create(resource: Resource with Create) = resource.createAction(service).get
+    /**
+     * Retrieve the corresponding CREATE Action for the given resource registered to a given service.
+     */
+    def create(resource: Resource with Create): Option[Action] = resource.create(service)
 
-    def update(resource: Resource with Update) = resource.updateAction(service).get
+    /**
+     * Retrieve the corresponding UPDATE Action for the given resource registered to a given service.
+     */
+    def update(resource: Resource with Update): Option[Action] = resource.update(service)
 
-    def delete(resource: Resource with Delete) = resource.deleteAction(service).get
+    /**
+     * Retrieve the corresponding DELETE Action for the given resource registered to a given service.
+     */
+    def delete(resource: Resource with Delete): Option[Action] = resource.delete(service)
 
   }
 

--- a/nrv-extension/src/test/scala/com/wajam/nrv/extension/resource/TestResource.scala
+++ b/nrv-extension/src/test/scala/com/wajam/nrv/extension/resource/TestResource.scala
@@ -3,8 +3,7 @@ package com.wajam.nrv.extension.resource
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FunSuite
-import com.wajam.nrv.service.{ActionPath, Service, ActionMethod}
-import com.wajam.nrv.data.InMessage
+import com.wajam.nrv.service.{Service, ActionMethod}
 
 /**
  * Test class for Resource
@@ -12,11 +11,13 @@ import com.wajam.nrv.data.InMessage
 @RunWith(classOf[JUnitRunner])
 class TestResource extends FunSuite {
 
+  val NoOp = (req: Request) => {}
+
   test("should have correct path for GET operation") {
     val testService = new Service("test")
 
     val resource = new Resource("test", "id") with Get {
-      protected def get: (Request) => Unit = ???
+      protected def get: (Request) => Unit = NoOp
     }
 
     resource.registerTo(testService)
@@ -29,7 +30,7 @@ class TestResource extends FunSuite {
     val testService = new Service("test")
 
     val resource = new Resource("test", "id") with List {
-      protected def list: (Request) => Unit = ???
+      protected def list: (Request) => Unit = NoOp
     }
 
     resource.registerTo(testService)
@@ -42,7 +43,7 @@ class TestResource extends FunSuite {
     val testService = new Service("test")
 
     val resource = new Resource("test", "id") with Create {
-      protected def create: (Request) => Unit = ???
+      protected def create: (Request) => Unit = NoOp
     }
 
     resource.registerTo(testService)
@@ -55,7 +56,7 @@ class TestResource extends FunSuite {
     val testService = new Service("test")
 
     val resource = new Resource("test", "id") with Update {
-      protected def update: (Request) => Unit = ???
+      protected def update: (Request) => Unit = NoOp
     }
 
     resource.registerTo(testService)
@@ -68,7 +69,7 @@ class TestResource extends FunSuite {
     val testService = new Service("test")
 
     val resource = new Resource("test", "id") with Delete {
-      protected def delete: (Request) => Unit = ???
+      protected def delete: (Request) => Unit = NoOp
     }
 
     resource.registerTo(testService)
@@ -81,11 +82,11 @@ class TestResource extends FunSuite {
     val testService = new Service("test")
 
     val resource = new Resource("test", "id") with Get with List with Create with Update with Delete {
-      protected def delete: (Request) => Unit = ???
-      protected def update: (Request) => Unit = ???
-      protected def get: (Request) => Unit = ???
-      protected def list: (Request) => Unit = ???
-      protected def create: (Request) => Unit = ???
+      protected def delete: (Request) => Unit = NoOp
+      protected def update: (Request) => Unit = NoOp
+      protected def get: (Request) => Unit = NoOp
+      protected def list: (Request) => Unit = NoOp
+      protected def create: (Request) => Unit = NoOp
     }
 
     resource.registerTo(testService)
@@ -97,19 +98,19 @@ class TestResource extends FunSuite {
     val testService = new Service("test")
 
     val resource1 = new Resource("test1", "id") with Get with List with Create with Update with Delete {
-      protected def delete: (Request) => Unit = ???
-      protected def update: (Request) => Unit = ???
-      protected def get: (Request) => Unit = ???
-      protected def list: (Request) => Unit = ???
-      protected def create: (Request) => Unit = ???
+      protected def delete: (Request) => Unit = NoOp
+      protected def update: (Request) => Unit = NoOp
+      protected def get: (Request) => Unit = NoOp
+      protected def list: (Request) => Unit = NoOp
+      protected def create: (Request) => Unit = NoOp
     }
 
     val resource2 = new Resource("test2", "id") with Get with List with Create with Update with Delete {
-      protected def delete: (Request) => Unit = ???
-      protected def update: (Request) => Unit = ???
-      protected def get: (Request) => Unit = ???
-      protected def list: (Request) => Unit = ???
-      protected def create: (Request) => Unit = ???
+      protected def delete: (Request) => Unit = NoOp
+      protected def update: (Request) => Unit = NoOp
+      protected def get: (Request) => Unit = NoOp
+      protected def list: (Request) => Unit = NoOp
+      protected def create: (Request) => Unit = NoOp
     }
 
     resource1.registerTo(testService)
@@ -122,20 +123,20 @@ class TestResource extends FunSuite {
     val testService = new Service("test")
 
     val resource = new Resource("test", "id") with Get with List with Create with Update with Delete {
-      protected def delete: (Request) => Unit = ???
-      protected def update: (Request) => Unit = ???
-      protected def get: (Request) => Unit = ???
-      protected def list: (Request) => Unit = ???
-      protected def create: (Request) => Unit = ???
+      protected def delete: (Request) => Unit = NoOp
+      protected def update: (Request) => Unit = NoOp
+      protected def get: (Request) => Unit = NoOp
+      protected def list: (Request) => Unit = NoOp
+      protected def create: (Request) => Unit = NoOp
     }
 
     resource.registerTo(testService)
 
-    assert(resource.getAction(testService).isDefined)
-    assert(resource.listAction(testService).isDefined)
-    assert(resource.createAction(testService).isDefined)
-    assert(resource.updateAction(testService).isDefined)
-    assert(resource.deleteAction(testService).isDefined)
+    assert(resource.get(testService).isDefined)
+    assert(resource.list(testService).isDefined)
+    assert(resource.create(testService).isDefined)
+    assert(resource.update(testService).isDefined)
+    assert(resource.delete(testService).isDefined)
   }
 
 }


### PR DESCRIPTION
This is to avoid duplicating code when defining REST like services.
- Created a Resource trait that encapsulate a Resource definition.
- Created a Request helper class to ease extraction of parameters from InMessage. This will also evolve very soon.
- Created a ResourcefulService that is a implicit wrapper on a service to add Resource registration methods.
