### PR TITLE
Fix error handling in HttpProtocol

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/RouteException.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/RouteException.scala
@@ -3,6 +3,4 @@ package com.wajam.nrv
 /**
  * Exception throw in messages routing
  */
-class RouteException(msg: String, val function: Int) extends Exception(msg) {
-
-}
+case class RouteException(msg: String) extends Exception(msg)

--- a/nrv-core/src/main/scala/com/wajam/nrv/protocol/Protocol.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/protocol/Protocol.scala
@@ -64,13 +64,13 @@ abstract class Protocol(val name: String,
         }
         case None =>
           error("Couldn't find services/action for received message {}", message)
-          throw new RouteException("No route found for received message " + message.toString, message.function)
+          throw new RouteException("No route found for received message " + message.toString)
       }
 
     } catch {
       case e: RouteException => {
         routingError.mark()
-        handleIncomingMessageError(e, message.attachments(Protocol.CONNECTION_KEY).asInstanceOf[Option[AnyRef]])
+        handleIncomingMessageError(message, e, message.attachments(Protocol.CONNECTION_KEY).asInstanceOf[Option[AnyRef]])
       }
     }
   }
@@ -177,17 +177,17 @@ abstract class Protocol(val name: String,
       case pe: ParsingException => {
         parsingError.mark()
         warn("Parsing exception: {}", pe)
-        handleIncomingMessageError(pe, connectionInfo)
+        handleIncomingMessageError(message, pe, connectionInfo)
       }
       case e: Exception => {
         receptionError.mark()
         warn("Exception caught while processing a message from transport", e)
-        handleIncomingMessageError(e, connectionInfo)
+        handleIncomingMessageError(message, e, connectionInfo)
       }
     }
   }
 
-  protected def handleIncomingMessageError(exception: Exception, connectionInfo: Option[AnyRef]) {}
+  protected def handleIncomingMessageError(message: AnyRef, exception: Exception, connectionInfo: Option[AnyRef]) {}
 
   /**
    * Parse the received message and convert it to a standard Message object.
@@ -249,6 +249,6 @@ object Protocol {
   val FLAGS = "flags"
 }
 
-case class ParsingException(message: String, function: Int, code: Int = 400) extends Exception(message)
+case class ParsingException(message: String, code: Int = 400) extends Exception(message)
 
 case class ListenerException(message: String) extends Exception(message)

--- a/nrv-core/src/main/scala/com/wajam/nrv/transport/netty/NettyTransport.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/transport/netty/NettyTransport.scala
@@ -139,6 +139,8 @@ abstract class NettyTransport(host: InetAddress,
 
   def writeOnChannel(channel: Channel, message: AnyRef): ChannelFuture = channel.write(message)
 
+  def closeChannel(channel: Option[AnyRef]) = channel.map(_.asInstanceOf[Channel].close())
+
   class NettyServer(host: InetAddress, port: Int, factory: NettyTransportCodecFactory) extends Logging {
 
     val serverMessageHandler = new MessageHandler(true)

--- a/nrv-core/src/test/scala/com/wajam/nrv/protocol/TestNrvProtocolWithCluster.scala
+++ b/nrv-core/src/test/scala/com/wajam/nrv/protocol/TestNrvProtocolWithCluster.scala
@@ -134,7 +134,7 @@ class TestNrvProtocolWithCluster extends FunSuite with BeforeAndAfter with Shoul
 
     val protocol = new NrvProtocol(cluster.localNode, 10000, 100) {
       override def parse(message: AnyRef, flags: Map[String, Any]): Message = {
-        throw new ParsingException("400", FUNCTION_RESPONSE)
+        throw new ParsingException("400")
       }
 
       override def handleIncoming(action: Action, message: InMessage) {


### PR DESCRIPTION
Since we added support for multiple protocols in actions, there has been a regression on protocol-level error handling. Instead of replying with the error message, we were actually closing the connection.

This fix takes into account the `function` flag of the incoming message to know whether we need to reply or not:
- function call: reply
- function response: don't

It also comes with a bunch of tests to ensure this doesn't happen again.
