### PR TITLE
Startable trait used by Service

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/service/Service.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/service/Service.scala
@@ -66,9 +66,7 @@ class Service(val name: String, actionSupportOptions: ActionSupportOptions = new
     }).map(node => node.element)
   }
 
-  override def start() {
-    super.start()
-
+  def start() {
     for (action <- this.actions) {
       action.start()
     }
@@ -76,9 +74,7 @@ class Service(val name: String, actionSupportOptions: ActionSupportOptions = new
     consistency.start()
   }
 
-  override def stop() {
-    super.stop()
-
+  def stop() {
     for (action <- this.actions) {
       action.stop()
     }

--- a/nrv-core/src/main/scala/com/wajam/nrv/utils/Startable.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/utils/Startable.scala
@@ -8,10 +8,10 @@ trait Startable {
   /**
    * Start this component.
    */
-  def start() {}
+  def start()
 
   /**
    * Stop this component.
    */
-  def stop() {}
+  def stop()
 }


### PR DESCRIPTION
Allows trait that can be mix-in with Service to override start() or stop() and call super implementation.
