### PR TITLE
Fix slave consistency recovery

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/FileTransactionLog.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/log/FileTransactionLog.scala
@@ -287,7 +287,10 @@ class FileTransactionLog(val service: String, val token: Long, val logDir: Strin
         }
       }
 
-      result.get
+      result match {
+        case Some(itr) => itr
+        case None => throw new NoSuchElementException(timestamp.toString)
+      }
     }
   }
 


### PR DESCRIPTION
Consistency recovery must not fail when store and tx log are both empty. 

Also included: 
- Fix a few error messages
- include start timestamp in error when try to read log and the starting timestamp is not found. The behaviour is exactly the same but this is now easier to debug...
