### PR TITLE
Fixes for easier ZookeeperConsistencyPersistence integration

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/service/ExplicitReplicaResolver.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/service/ExplicitReplicaResolver.scala
@@ -1,7 +1,5 @@
 package com.wajam.nrv.service
 
-import com.wajam.nrv.service._
-import scala.Some
 import com.wajam.nrv.cluster.Node
 
 /**
@@ -10,7 +8,7 @@ import com.wajam.nrv.cluster.Node
  * on the specified explicit configuration. The master of the shard is resolved through nrv mechanics and added as
  * the head of the resolved node list. All other nodes are considered to be replicas.
  */
-class ExplicitReplicaResolver(explicitTokenMapping: Map[Long,List[Node]], resolver: Resolver)
+class ExplicitReplicaResolver(explicitTokenMapping: => Map[Long,List[Node]], resolver: Resolver)
   extends Resolver(resolver.replica, resolver.tokenExtractor, resolver.constraints, resolver.sorter) {
 
   override def resolve(service: Service, token: Long) = {

--- a/nrv-zookeeper/src/main/scala/com/wajam/nrv/zookeeper/consistency/ZookeeperConsistencyPersistence.scala
+++ b/nrv-zookeeper/src/main/scala/com/wajam/nrv/zookeeper/consistency/ZookeeperConsistencyPersistence.scala
@@ -27,6 +27,8 @@ class ZookeeperConsistencyPersistence(zk: ZookeeperClient, service: Service)(imp
   private val serviceObserver: (Event) => Unit = {
     case NewMemberAddedEvent(member) =>
       updateReplicasMapping()
+
+    case _ =>
   }
 
   def start(): Unit = {
@@ -45,11 +47,11 @@ class ZookeeperConsistencyPersistence(zk: ZookeeperClient, service: Service)(imp
 
   def explicitReplicasMapping: Map[Long, List[Node]] = mapping
 
-  def replicationLagSeconds(token: Long, node: Node): Option[Int] = ???
+  def replicationLagSeconds(token: Long, node: Node): Option[Int] = None
 
-  def replicationLagSeconds_= (token: Long, node: Node, lag: Option[Int]) = ???
+  def replicationLagSeconds_= (token: Long, node: Node, lag: Option[Int]) = Unit
 
-  def changeMasterServiceMember(token: Long, node: Node) = ???
+  def changeMasterServiceMember(token: Long, node: Node) = Unit
 
   private def mappingFuture = mappingFetcher.ask(Fetch).mapTo[(Int, ReplicasMapping)]
 


### PR DESCRIPTION
- Fix a MatchError in service's Observer
- Fix type inference mess due to ???
- Use a pass-by-name explicitTokenMapping in ExplicitReplicaResolver
