### PR TITLE
Raise ask and await timeouts in ZookeeperConsistencyPersistence

### DIFF
--- a/nrv-zookeeper/src/main/scala/com/wajam/nrv/zookeeper/consistency/ZookeeperConsistencyPersistence.scala
+++ b/nrv-zookeeper/src/main/scala/com/wajam/nrv/zookeeper/consistency/ZookeeperConsistencyPersistence.scala
@@ -1,5 +1,6 @@
 package com.wajam.nrv.zookeeper.consistency
 
+import scala.language.postfixOps
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Await
 import scala.concurrent.duration._


### PR DESCRIPTION
Avoids Edge startup failures in case of slow Zookeeper connection.
