### PR TITLE
Remove dependency on nrv-core for nrv-scribe

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -112,7 +112,6 @@ object NrvBuild extends Build {
     .settings(libraryDependencies ++= scribeDeps)
     .settings(testOptions in IntegrationTest := Seq(Tests.Filter(s => s.contains("Test"))))
     .settings(parallelExecution in IntegrationTest := false)
-    .dependsOn(core)
 
   lazy val microbenchmarks = Project(PROJECT_NAME + "-microbenchmarks", file(PROJECT_NAME + "-microbenchmarks"))
     .configs(IntegrationTest)


### PR DESCRIPTION
(I don't have time to extract it to scala-commons, so this should ease the usage of the Scribe client)

@clementgarnier @mlaflamm 
