### PR TITLE
Prevent service member joining when not started yet.

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
@@ -205,7 +205,7 @@ class ConsistencyMasterSlave(val timestampGenerator: TimestampGenerator,
 
     event match {
       case event: StatusTransitionAttemptEvent if txLogEnabled => {
-        handleStatusTransitionAttemptEvent(event)
+        if (started) handleStatusTransitionAttemptEvent(event) else event.vote(pass = false)
       }
       case event: StatusTransitionEvent if cluster.isLocalNode(event.member.node) => {
         handleLocalServiceMemberStatusTransitionEvent(event)


### PR DESCRIPTION
DynamicClusterManager attempt to change the service member status from down to joining before the cluster is fully started. This check prevent the transition until ConsistencyMasterSlave is started.
