### PR TITLE
Allow Down transition if no master replication session for the transitionning member

### DIFF
--- a/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
+++ b/nrv-core/src/main/scala/com/wajam/nrv/consistency/ConsistencyMasterSlave.scala
@@ -269,7 +269,9 @@ class ConsistencyMasterSlave(val timestampGenerator: TimestampGenerator,
         // Trying to transition the service member Down.
         // When Leaving, allows the transition only if the service member is not the master of a live
         // replication session. Allow transitions from any other status.
-        val liveSessions = masterReplicationSessionManager.sessions.filter(_.mode == ReplicationMode.Live).toList
+        val liveSessions = masterReplicationSessionManager.sessions.filter { session =>
+          session.mode == ReplicationMode.Live && session.member.token == event.member.token
+        }.toList
         val canTransition = liveSessions.isEmpty || event.from != MemberStatus.Leaving
         def currentState = if (canTransition) None else consistencyStates.get(event.member.token)
         info("StatusTransitionAttemptEvent: status=Down, prevState={}, newState=None, member={}, live replications={}",


### PR DESCRIPTION
Was preventing transition before if a master replication session for another member existed. This prevented live mastership migration from a node with two master shards.
