### PR TITLE
Add support for reformatted json string response into JsonApiDSL

### DIFF
--- a/nrv-extension/src/main/scala/com/wajam/nrv/extension/json/JsonApiDSL.scala
+++ b/nrv-extension/src/main/scala/com/wajam/nrv/extension/json/JsonApiDSL.scala
@@ -71,6 +71,7 @@ trait JsonApiDSL extends Service {
           case Failure(t) => Future.failed(t)
         }
         fut.onComplete {
+          case Success((Some(v: String), headers)) => i.replyString(v, headers = headers)
           case Success((Some(v), headers)) => i.replyJson(v, headers = headers)
           case Success((None, headers)) => i.replyEmpty(headers = headers)
           case Failure(e: ResponseException) => i.replyEmpty(e.code, e.headers)
@@ -171,6 +172,10 @@ trait JsonApiDSL extends Service {
 
     def replyJson(obj: AnyRef, code: Int = 200, headers: Map[String, String] = Map.empty) {
       msg.reply(Map(), RESPONSE_HEADERS ++ headers, Serialization.write(obj), code)
+    }
+
+    def replyString(value: String, code: Int = 200, headers: Map[String, String] = Map.empty) {
+      msg.reply(Map(), RESPONSE_HEADERS ++ headers, value, code)
     }
 
     def replyError(message: String, code: Int = 500, headers: Map[String, String] = Map.empty) {


### PR DESCRIPTION
The response body is passes as is and no validation is made to ensure the response body is valid json.
